### PR TITLE
Subcommand reflects 'abaco <command>' pattern instead of 'abaco-command.sh'

### DIFF
--- a/abaco
+++ b/abaco
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 
-HELP="
-./abaco [COMMAND] [OPTION]...
+THIS=$(basename $0)
 
-Set of commands for interacting with abaco API. Options vary by 
-command; use -h flag after command to view.
+HELP="
+Usage: ${THIS} [COMMAND] [OPTION]...
+
+Set of commands for interacting with Abaco API. Options vary by 
+command; use -h flag after command to view usage details.
 
 Commands:
-  list, ls, actors, images	list actors
+  list, ls, actors, images	    list actors
   create, make, register        create new actor
   delete, remove, rm            remove actor
   workers, worker               view and add workers
   submit, run                   run actor
   executions                    view actor executions
-  logs				view execution logs
+  logs				                  view execution logs
 "
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/abaco-create.sh
+++ b/abaco-create.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+THIS=$(basename $0)
+THIS=${THIS%.sh}
+THIS=${THIS//[-]/ }
+
 HELP="
-./abaco-create.sh [OPTION]... [IMAGE]
+Usage: ${THIS} [OPTION]... [IMAGE]
 
 Creates an abaco actor from the provided image and returns the name and ID
 of the actor.

--- a/abaco-delete.sh
+++ b/abaco-delete.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+THIS=$(basename $0)
+THIS=${THIS%.sh}
+THIS=${THIS//[-]/ }
+
 HELP="
-./abaco-delete.sh [OPTION]... [ACTORID]
+Usage: ${THIS} [OPTION]... [ACTORID]
 
 Deletes the actor corresponding to the given actor ID
 

--- a/abaco-executions.sh
+++ b/abaco-executions.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+THIS=$(basename $0)
+THIS=${THIS%.sh}
+THIS=${THIS//[-]/ }
+
 HELP="
-./abaco-executions.sh [OPTION]... [ACTORID]
+Usage: ${THIS}[OPTION]... [ACTORID]
 
 Returns list of execution IDs for the provided actor or JSON description 
 of execution if execution ID provided with -e flag.

--- a/abaco-list.sh
+++ b/abaco-list.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+THIS=$(basename $0)
+THIS=${THIS%.sh}
+THIS=${THIS//[-]/ }
+
 HELP="
-./abaco-list.sh [OPTION]...
-./abaco-list.sh [OPTION]... [ACTORID]
+Usage: ${THIS} [OPTION]...
+       ${THIS} [OPTION]... [ACTORID]
 
 Returns list of actor names, IDs, and statuses or JSON description of 
 actor if ID provided

--- a/abaco-logs.sh
+++ b/abaco-logs.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+THIS=$(basename $0)
+THIS=${THIS%.sh}
+THIS=${THIS//[-]/ }
+
 HELP="
-./abaco-logs.sh [OPTION]... [ACTORID]
+Usage: ${THIS} [OPTION]... [ACTORID]
 
 Prints logs for actor and exection IDs provided, respectively. Both 
 inputs are required.

--- a/abaco-submit.sh
+++ b/abaco-submit.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+THIS=$(basename $0)
+THIS=${THIS%.sh}
+THIS=${THIS//[-]/ }
+
 HELP="
-./abaco-submit.sh [OPTION]... [ACTORID]
+Usage: ${THIS} [OPTION]... [ACTORID]
 
 Executes the actor with provided ID and returns execution ID. Message (-m) 
 is required and can be string or JSON.

--- a/abaco-workers.sh
+++ b/abaco-workers.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+THIS=$(basename $0)
+THIS=${THIS%.sh}
+THIS=${THIS//[-]/ }
+
 HELP="
-./abaco-workers.sh [OPTION]... [ACTORID]
+Usage: ${THIS} [OPTION]... [ACTORID]
 
 Returns list of worker IDs and statuses or JSON description of worker 
 if worker ID provided with -w flag. Use -n flag to change worker count.


### PR DESCRIPTION
Applying a few lessons learned from building contained and other SD2E tooling to improve how the subcommands display their help. 